### PR TITLE
Suggestions for change to Vale rules

### DIFF
--- a/.github/styles/MongoDB/Accessibility.yml
+++ b/.github/styles/MongoDB/Accessibility.yml
@@ -11,7 +11,6 @@ tokens:
   - affected by
   - an epileptic
   - crippled
-  - disabled
   - dumb
   - handicapped
   - handicaps

--- a/.github/styles/MongoDB/NegativeWords.yml
+++ b/.github/styles/MongoDB/NegativeWords.yml
@@ -10,12 +10,7 @@ swap:
   damage: affect
   catastrophic: serious
   bad: Use serious or add an explanation
-  fail: unable to
   kill: cancel
   fatal: serious
   destroy: remove, delete
   wrong: incorrect, inconsistent
-
-exceptions:
-  - '.*-fail'
-  - 'fail-.*'


### PR DESCRIPTION
JIRA - <https://jira.mongodb.org/browse/DOCSP-33817>

Associated Vale PR: <https://github.com/mongodb/docs-meta/pull/163>

## Recommendations 

### Use of "Fail"
The current vale instruction throws an error when this word is used, based on the style guide instruction to [avoid the use of negative words](https://www.mongodb.com/docs/meta/style-guide/writing/use-positive-statements/#avoid-negative-words). 

However, many systems self-describe their behaviour as "failed". The word "fail" is used in several examples of proper writing within the style guide itself, including as [preferred choice over "did not run successfully" on the Concise Terms page](https://www.mongodb.com/docs/meta/style-guide/terminology/concise-terms/).

#### Recommendation
Remove Vale error and clarify acceptable use in the style guide. "Fail" should not be used to describe the actions of an individual or the company, but is acceptable to describe system performance.

### Use of "Disable"

The current vale instruction throws an error when this word is used, based on [Microsoft's Accessibility terms](https://learn.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/term-collections/accessibility-terms).

However, many systems describe features as disabled in warnings, or in the configuration setting name. This is actually called out in the [terminology glossary](https://www.mongodb.com/docs/meta/style-guide/terminology/alphabetical-terms/#d).

#### Recommendation
Remove Vale error and clarify acceptable use in the style guide. "Disable" should be used only in cases that describe whether or not a system employs a feature.
