### PR TITLE
Remove conflicting rule: "etc" vs "and so on"

### DIFF
--- a/.github/styles/MongoDB/Avoid.yml
+++ b/.github/styles/MongoDB/Avoid.yml
@@ -6,7 +6,6 @@ level: error
 tokens:
   - abortion
   - and/or
-  - and so on
   - slash mark
   - billion
   - biweekly


### PR DESCRIPTION
There are two conflicting rules in Vale:
One says to [use "and so on" instead of "etc"](https://github.com/mongodb/mongodb-vale-action/blob/f36a73b1f81468673f7558be5e4e0339f31e2c33/.github/styles/MongoDB/AvoidObscure.yml#L10), the other says [not to use "and so on"](https://github.com/mongodb/mongodb-vale-action/blob/f36a73b1f81468673f7558be5e4e0339f31e2c33/.github/styles/MongoDB/Avoid.yml#L9).

The style guide says to [use "and so on" in place of "etc"](https://www.mongodb.com/docs/meta/style-guide/terminology/alphabetical-terms/#e). "And so on" is not listed in the style guide and I couldn't find any reference to avoiding it.